### PR TITLE
better explanation of security codes

### DIFF
--- a/schema/sxl.yaml
+++ b/schema/sxl.yaml
@@ -1829,8 +1829,8 @@ objects:
       M0103:
         description: |-
           Set security code.
-          Change the security code to use when sending commands
-          Security codes are used as an extra layer of security in many commands. They need to match between the supervision system and the traffic light controller in order for the commands to be executed.
+          Change a security code used when sending commands.
+          Security codes are shared application-level values. The code required by a command must match between the supervision system and the traffic light controller for the command to be executed. Security codes are not cryptographic protection.
         from_version: 1.0.1
         arguments:
           status:

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -16,6 +16,7 @@ The full list of changes between 1.3.0 and 1.2.1 can be viewed on github.
 - M0020: Fixed True/False mixed up :issue:`191`
 - M0008: Add ability to only force detector logic for a short duration :issue:`158`
 - Show sxl version info for each command/status and attribute :issue:`138`
+- Clarify the purpose and security limitations of security codes.
 
 Version 1.2.1
 -------------

--- a/source/security_codes.rst
+++ b/source/security_codes.rst
@@ -1,7 +1,31 @@
 Security codes
 ==============
-The SXL for TLCs uses security codes as part of most commands.
+The SXL for traffic light controllers defines two security-code levels. The
+description of each command states whether security code 1 or security code 2
+is required.
+
+Purpose and behaviour
+---------------------
+
+A security code is a shared application-level value. When a command requires a
+security code, the supervision system includes the configured value in the
+``securityCode`` argument. The traffic light controller compares it with the
+configured code for the required level before executing the command.
+
+Security codes provide a limited command-authorization check. They are carried
+inside RSMP messages and do not encrypt or cryptographically authenticate those
+messages. They do not provide confidentiality, message integrity, peer
+authentication, or replay protection. Anyone who can obtain a valid code and
+send commands to the traffic light controller may be able to use it.
+
+Security codes must therefore be treated as credentials and protected in
+configuration, communication, logs, and backups. They are not a replacement
+for communication protection, network access control, or authorization in the
+complete deployment.
 
 Incorrect security codes
 ------------------------
-If an incorrect security code is used, then the TLC replies with ``MessageNotAck`` where ``rea`` is set to ``Incorrect security code``.
+
+If a security code does not match the configured code for the required level,
+the traffic light controller replies with ``MessageNotAck`` where ``rea`` is
+set to ``Incorrect security code``.

--- a/source/sxl_traffic_light_controller.rst
+++ b/source/sxl_traffic_light_controller.rst
@@ -3556,10 +3556,11 @@ M0103 Set security code
 
 Available from SXL version: ``1.0.1``
 
-Change the security code to use when sending commands Security codes are
-used as an extra layer of security in many commands. They need to match
-between the supervision system and the traffic light controller in order
-for the commands to be executed.
+Change a security code used when sending commands. Security codes are
+shared application-level values. The code required by a command must
+match between the supervision system and the traffic light controller
+for the command to be executed. Security codes are not cryptographic
+protection.
 
 
 **Arguments**


### PR DESCRIPTION
Make it more explicit the `securityCode` is not related to cryptographic security.